### PR TITLE
fix: drop the dead @tylervigario/performance devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.3.3",
       "license": "MIT",
       "devDependencies": {
-        "@tylervigario/performance": "github:TylerVigario/performance",
         "ava": "^5.3.0",
         "c8": "^8.0.0",
         "eslint": "^8.42.0",
@@ -199,15 +198,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@tylervigario/performance": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TylerVigario/performance.git#d4f5e09bcc664f129ad94eef1b811add5ab3ce34",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     ]
   },
   "devDependencies": {
-    "@tylervigario/performance": "github:TylerVigario/performance",
     "ava": "^5.3.0",
     "c8": "^8.0.0",
     "eslint": "^8.42.0",


### PR DESCRIPTION
`package.json` depended on `github:TylerVigario/performance`. **That repository returns 404.**

```
npm error command git ... ls-remote ssh://git@github.com/TylerVigario/performance.git
npm error git@github.com: Permission denied (publickey).
```

So `npm ci` exits **128 for everyone** — not just CI, not just this branch. Anyone cloning this repo cannot install it.

Nothing imports it. The dependency line was the only reference in the entire tree:

```
$ grep -rn 'performance' --include='*.js' --include='*.json' --include='*.yml' . | grep -v package-lock
package.json:48:    "@tylervigario/performance": "github:TylerVigario/performance",
```

## Measured

```
before   npm ci  exit 128
after    npm ci  exit 0
```

Lockfile regenerated with npm 11.16.0 — past the version that dropped libc guards.

## What this reveals

With the install fixed, **the test suite runs for the first time in a long while — and one test fails.**

```
✘ US: Parse tests  →  7000 grains
   - actual    0.9999999799999999
   + expected  1
```

That is a real pre-existing bug, not a consequence of this change: nothing here touched `lib/`. It was invisible because `npm ci` died before `ava` ever started, which is the worst version of a red build — one that never ran.

Filed separately, with a fix in its own PR, so this one stays what it says it is.
