### PR TITLE
fix: define a grain as exactly one seven-thousandth of a pound

### DIFF
--- a/lib/units/UK.js
+++ b/lib/units/UK.js
@@ -72,7 +72,7 @@ export default [{
   ],
 }, {
   name: 'grain',
-  value: 0.00014285714,
+  value: 1 / 7000,
   signifiers: [
     'gr',
     'grain',

--- a/lib/units/US.js
+++ b/lib/units/US.js
@@ -62,7 +62,7 @@ export default [{
   ],
 }, {
   name: 'grain',
-  value: 0.00014285714,
+  value: 1 / 7000,
   signifiers: [
     'gr',
     'grain',


### PR DESCRIPTION
Stacked on #16 — that one makes `npm ci` work, which is what let this surface at all. **Merge #16 first.**

A grain is defined as exactly **1/7000 lb**. The constant was a truncated decimal:

```js
value: 0.00014285714     // eleven places
```

```
7000 × 0.00014285714        = 0.9999999799999999
7000 × (1 / 7000)           = 1                    exactly, in IEEE 754
```

So `parse('7000 grains')` returned `0.9999999799999999` instead of `1`. The drift came entirely from truncating the literal — not from floating point being unable to represent the answer.

## Why only grain

Every other constant in the library is a binary-exact fraction, which is why none of them drift:

| unit | value | round-trips |
| --- | --- | --- |
| pound / kilogram | `1` | exact |
| ounce | `0.0625` | exact |
| dram | `0.00390625` | exact |
| gram | `0.001` | exact |
| **grain** | `0.00014285714` | **0.99999998** |

`1/7000` is not representable in binary, so it is the one place a written-out decimal loses. Present identically in `US.js` and `UK.js`; both fixed.

## Verified

```
before   1 test failed   ✘ US: Parse tests → 7000 grains
after    14 tests passed
```

And a sweep over every unit in all three systems: **0 that do not round-trip exactly.**

## How long this was broken

Unknown, and it was invisible rather than ignored — `npm ci` exited 128 on a dead dependency, so `ava` never started. A red build that never ran looks the same as one nobody looked at.
