### PR TITLE
fix: define a grain as exactly one seven-thousandth of a pound

### DIFF
--- a/lib/units/UK.js
+++ b/lib/units/UK.js
@@ -72,7 +72,7 @@ export default [{
   ],
 }, {
   name: 'grain',
-  value: 0.00014285714,
+  value: 1 / 7000,
   signifiers: [
     'gr',
     'grain',

--- a/lib/units/US.js
+++ b/lib/units/US.js
@@ -62,7 +62,7 @@ export default [{
   ],
 }, {
   name: 'grain',
-  value: 0.00014285714,
+  value: 1 / 7000,
   signifiers: [
     'gr',
     'grain',


### PR DESCRIPTION
Replaces #17, which GitHub closed automatically when its base branch was deleted on the merge of #16. Same branch, rebased onto `master`, now a two-line diff.

A grain is defined as exactly **1/7000 lb**. The constant was a truncated decimal:

```js
value: 0.00014285714     // eleven places
```

```
7000 × 0.00014285714   = 0.9999999799999999
7000 × (1 / 7000)      = 1                    exactly, in IEEE 754
```

`parse('7000 grains')` returned `0.9999999799999999` instead of `1`. The drift came entirely from truncating the literal — not from floating point being unable to hold the answer.

## Why only grain

Every other constant is a binary-exact fraction, which is why none of them drift:

| unit | value | round-trips |
| --- | --- | --- |
| pound / kilogram | `1` | exact |
| ounce | `0.0625` | exact |
| dram | `0.00390625` | exact |
| gram | `0.001` | exact |
| **grain** | `0.00014285714` | **0.99999998** |

`1/7000` is not representable in binary, so it is the one place a written-out decimal loses. Identical in `US.js` and `UK.js`; both fixed.

## Verified

```
before   1 test failed   ✘ US: Parse tests → 7000 grains
after    14 tests passed
```

Plus a sweep over every unit in all three systems: **0 that do not round-trip exactly.**

## How long this was broken

Unknown, and invisible rather than ignored — `npm ci` exited 128 on a dead dependency, so `ava` never started. A red build that never ran looks the same as one nobody looked at.
